### PR TITLE
Bump the version number to find a working buildnumber-maven-plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -761,7 +761,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>buildnumber-maven-plugin</artifactId>
-				<version>1.1</version>
+				<version>1.3</version>
 				<executions>
 					<execution>
 						<phase>validate</phase>


### PR DESCRIPTION
I've not tested this to see if it still picks up a valid build number.